### PR TITLE
Added Lock.extend

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -14,9 +14,9 @@ var util = require('util');
  * @param {string} message The message to assign the error
  */
 function LockAcquisitionError(message) {
-    Error.captureStackTrace(this, LockAcquisitionError);
-    this.name = 'LockAcquisitionError';
-    this.message = message;
+  Error.captureStackTrace(this, LockAcquisitionError);
+  this.name = 'LockAcquisitionError';
+  this.message = message;
 }
 
 /**
@@ -29,9 +29,9 @@ function LockAcquisitionError(message) {
  * @param {string} message The message to assign the error
  */
 function LockReleaseError(message) {
-    Error.captureStackTrace(this, LockReleaseError);
-    this.name = 'LockReleaseError';
-    this.message = message;
+  Error.captureStackTrace(this, LockReleaseError);
+  this.name = 'LockReleaseError';
+  this.message = message;
 }
 
 /**
@@ -44,9 +44,9 @@ function LockReleaseError(message) {
  * @param {string} message The message to assign the error
  */
 function LockExtendError(message) {
-    Error.captureStackTrace(this, LockExtendError);
-    this.name = 'LockExtendError';
-    this.message = message;
+  Error.captureStackTrace(this, LockExtendError);
+  this.name = 'LockExtendError';
+  this.message = message;
 }
 
 util.inherits(LockAcquisitionError, Error);

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -14,9 +14,9 @@ var util = require('util');
  * @param {string} message The message to assign the error
  */
 function LockAcquisitionError(message) {
-  Error.captureStackTrace(this, LockAcquisitionError);
-  this.name = 'LockAcquisitionError';
-  this.message = message;
+    Error.captureStackTrace(this, LockAcquisitionError);
+    this.name = 'LockAcquisitionError';
+    this.message = message;
 }
 
 /**
@@ -29,13 +29,30 @@ function LockAcquisitionError(message) {
  * @param {string} message The message to assign the error
  */
 function LockReleaseError(message) {
-  Error.captureStackTrace(this, LockReleaseError);
-  this.name = 'LockReleaseError';
-  this.message = message;
+    Error.captureStackTrace(this, LockReleaseError);
+    this.name = 'LockReleaseError';
+    this.message = message;
+}
+
+/**
+ * The constructor for a LockExtendError. Thrown or returned when a lock
+ * could not be extended.
+ *
+ * @constructor
+ * @extends Error
+ *
+ * @param {string} message The message to assign the error
+ */
+function LockExtendError(message) {
+    Error.captureStackTrace(this, LockExtendError);
+    this.name = 'LockExtendError';
+    this.message = message;
 }
 
 util.inherits(LockAcquisitionError, Error);
 util.inherits(LockReleaseError, Error);
+util.inherits(LockExtendError, Error);
 
 exports.LockAcquisitionError = LockAcquisitionError;
 exports.LockReleaseError     = LockReleaseError;
+exports.LockExtendError      = LockExtendError;

--- a/lib/lock.js
+++ b/lib/lock.js
@@ -6,6 +6,7 @@ var scripts     = require('./scripts');
 
 var LockAcquisitionError = errors.LockAcquisitionError;
 var LockReleaseError     = errors.LockReleaseError;
+var LockExtendError      = errors.LockExtendError;
 
 /**
  * The constructor for a Lock object. Accepts both a redis client, as well as
@@ -55,7 +56,7 @@ function Lock(client, options) {
 Lock._defaults = {
   timeout: 10000,
   retries: 0,
-  delay: 50,
+  delay: 50
 };
 
 /**
@@ -127,7 +128,6 @@ Lock.prototype.acquire = function(key, fn) {
  * if no callback is supplied. If invoked in the context of a promise, it may
  * throw a LockReleaseError.
  *
- * @param {string}   key  The redis key to use for the lock
  * @param {function} [fn] Optional callback to invoke
  *
  * @returns {Promise}
@@ -168,6 +168,48 @@ Lock.prototype.release = function(fn) {
 };
 
 /**
+ * Attempts to extend the timeout of a lock, and accepts an optional callback function.
+ * The callback is invoked with an error on failure, and returns a promise
+ * if no callback is supplied. If invoked in the context of a promise, it may
+ * throw a LockExtendError.
+ *
+ * @param {number}   timeo The time in ms to extend this lock
+ * @param {function} [fn]  Optional callback to invoke
+ *
+ * @returns {Promise}
+ */
+Lock.prototype.extend = function(time, fn) {
+  var lock   = this;
+  var key    = this._key;
+  var shaval = this._shavaluator;
+
+  return new Promise(function(resolve, reject) {
+    // The lock must be held
+    if (!lock._locked) {
+      throw new LockExtendError('Lock has not been acquired');
+    }
+
+    resolve();
+  }).then(function() {
+        return shaval.execAsync('pexpireifequal', [key], [lock._id, time]);
+      }).then(function(res) {
+        // The key had already expired
+        if (!res) {
+          throw new LockExtendError('Lock on "' + key + '" had expired');
+        }
+
+        return Promise.resolve();
+      }).catch(function(err) {
+        // Wrap redis and shaval errors
+        if (!(err instanceof LockExtendError)) {
+          err = new LockExtendError(err.message);
+        }
+
+        throw err;
+      }).nodeify(fn);
+};
+
+/**
  * Invokes bluebird.promisify on a client's required commands if it does not
  * match a previously used redis client and does not have the necessary async
  * methods. Stores the result for use by the lock.
@@ -205,7 +247,7 @@ Lock.prototype._setupClient = function(client) {
  * Attempts to find a previously created Shavaluator associated with the given
  * redis client, and if found, stores it as a property. Otherwise it creates
  * a new Shavaluator, invokes Bluebird's promisifyAll, and adds the required
- * lua script for 'delifequal'.
+ * lua script for 'delifequal' and 'pexpireifequal'.
  *
  * @param {RedisClient} client The node_redis client to use
  *
@@ -218,6 +260,7 @@ Lock.prototype._setupLuaScripts = function(client) {
     Lock._shavaluators[id] = new Shavaluator(client);
     Promise.promisifyAll(Lock._shavaluators[id]);
     Lock._shavaluators[id].add('delifequal', scripts.delifequal);
+    Lock._shavaluators[id].add('pexpireifequal', scripts.pexpireifequal);
   }
 
   this._shavaluator = Lock._shavaluators[id];

--- a/lib/redislock.js
+++ b/lib/redislock.js
@@ -58,3 +58,8 @@ exports.LockAcquisitionError = errors.LockAcquisitionError;
  * The constructor function for a LockReleaseError.
  */
 exports.LockReleaseError = errors.LockReleaseError;
+
+/**
+ * The constructor function for a LockExtendError.
+ */
+exports.LockExtendError = errors.LockExtendError;

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -3,9 +3,15 @@
  */
 
 module.exports = {
-  delifequal:
+  delifequal :
     "if redis.call('GET', KEYS[1]) == ARGV[1] then\n" +
     "  return redis.call('DEL', KEYS[1])\n" +
+    "end\n" +
+    "return 0",
+
+  pexpireifequal :
+    "if redis.call('GET', KEYS[1]) == ARGV[1] then\n" +
+    "  return redis.call('PEXPIRE', KEYS[1], ARGV[2])\n" +
     "end\n" +
     "return 0"
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redislock",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Node distributed locking using redis",
   "keywords": [
     "lock",


### PR DESCRIPTION
Added extend method, which enables locks to extend its timeout.
It's very useful for continuos processes when rather than set a timeout you want to refresh its lock constantly.
