### PR TITLE
Nodeify early returns to get consistency

### DIFF
--- a/lib/lock.js
+++ b/lib/lock.js
@@ -99,7 +99,7 @@ Lock.prototype.acquire = function(key, fn) {
   var client = this._client;
 
   if (lock._locked) {
-    return Promise.reject(new LockAcquisitionError('Lock already held'));
+    return Promise.reject(new LockAcquisitionError('Lock already held')).nodeify(fn);
   }
 
   return lock._attemptLock(key, lock.retries).then(function(res) {
@@ -132,7 +132,7 @@ Lock.prototype.release = function(fn) {
   var shaval = this._shavaluator;
 
   if (!lock._locked) {
-    return Promise.reject(new LockReleaseError('Lock has not been acquired'));
+    return Promise.reject(new LockReleaseError('Lock has not been acquired')).nodeify(fn);
   }
 
   return shaval.execAsync('delifequal', [key], [lock._id]).then(function(res) {
@@ -170,8 +170,17 @@ Lock.prototype.extend = function(time, fn) {
   var key    = this._key;
   var shaval = this._shavaluator;
 
+  if (!fn && typeof time === 'function') {
+    fn = time;
+    time = null;
+  }
+
+  if (!time) {
+    return Promise.reject(new LockExtendError('Time is required to extend lock')).nodeify(fn);
+  }
+
   if (!lock._locked) {
-    return Promise.reject(new LockExtendError('Lock has not been acquired'));
+    return Promise.reject(new LockExtendError('Lock has not been acquired')).nodeify(fn);
   }
 
   var expire = shaval.execAsync('pexpireifequal', [key], [lock._id, time]);


### PR DESCRIPTION
Since we added this package to our [solo worker library](https://github.com/VoxFeed/Solo) we noticed that when we sent a callback to handle errors, some promise rejections remained unhandled and our server logs where full of red with the same error.

This commit gives more consistency because we expect to handle all errors in the callback instead of getting some in the callback and some returned in a rejected promise.

Thanks!
