### PR TITLE
Readme example not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ lock.acquire('app:feature:lock', function(err) {
 Supports promises, thanks to bluebird, out of the box:
 
 ``` javascript
-var client = require('redis').createClient();
-var lock   = require('redislock').createLock(client);
+var client    = require('redis').createClient();
+var redislock = require('redislock');
+var lock      = redislock.createLock(client);
 
 var LockAcquisitionError = redislock.LockAcquisitionError;
 var LockReleaseError     = redislock.LockReleaseError;


### PR DESCRIPTION
- promises example throws error `ReferenceError: redislock is not defined`
- fixed by adding redislock import as separate variable