### PR TITLE
chore: upgrades

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ the release is unaffected by other watched keys.
 
 In addition to the above, most locking libraries aren't compatible with promises
 by default, and due to their API, require "promisifying" individual locks.
-`redislock` avoids this issue by taking advantage of bluebird's `nodeify`
+`redislock` avoids this issue by taking advantage of bluebird's `asCallback`
 function to offer an API that easily supports both callbacks and promises.
 
 ## API

--- a/lib/lock.js
+++ b/lib/lock.js
@@ -111,7 +111,7 @@ Lock.prototype.acquire = function(key, fn) {
     }
 
     throw err;
-  }).nodeify(fn);
+  }).asCallback(fn);
 };
 
 /**
@@ -151,7 +151,7 @@ Lock.prototype.release = function(fn) {
     }
 
     throw err;
-  }).nodeify(fn);
+  }).asCallback(fn);
 };
 
 /**
@@ -194,7 +194,7 @@ Lock.prototype.extend = function(time, fn) {
     }
 
     throw err;
-  }).nodeify(fn);
+  }).asCallback(fn);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/danielstjules/redislock.git"
   },
   "dependencies": {
-    "bluebird": "~2.9.30",
+    "bluebird": "~3.7.2",
     "redis-evalsha": "~1.1.1",
     "uuid": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "fakeredis": "*",
     "mocha": "2",
     "redis": "*",
-    "rewire": "*"
+    "proxyquire": "^2.1.3"
   },
   "scripts": {
     "test": "mocha -R spec spec"

--- a/package.json
+++ b/package.json
@@ -13,9 +13,7 @@
     "synchronization"
   ],
   "author": "Daniel St. Jules <danielst.jules@gmail.com>",
-  "licenses": [
-    "MIT"
-  ],
+  "license": "MIT",
   "main": "lib/redislock.js",
   "homepage": "https://github.com/danielstjules/redislock",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "expect.js": "*",
     "fakeredis": "*",
-    "mocha": "2",
+    "mocha": "^6.2.2",
     "redis": "*",
     "proxyquire": "^2.1.3"
   },

--- a/spec/lockSpec.js
+++ b/spec/lockSpec.js
@@ -29,7 +29,7 @@ describe('lock', function() {
       Lock._acquiredLocks[lock._id] = lock;
       lock._locked = true;
       lock._key = key;
-      return client.setAsync(key, lock._id).nodeify(fn);
+      return client.setAsync(key, lock._id).asCallback(fn);
     };
   };
 
@@ -37,7 +37,7 @@ describe('lock', function() {
   var mockRelease = function(lock) {
     lock.release = function(fn) {
       delete Lock._acquiredLocks[lock._id];
-      return client.delAsync(lock._key).nodeify(fn);
+      return client.delAsync(lock._key).asCallback(fn);
     };
   };
 

--- a/spec/lockSpec.js
+++ b/spec/lockSpec.js
@@ -228,7 +228,7 @@ describe('lock', function() {
     });
 
     it('is compatible with callbacks', function(done) {
-      return lock.acquire('propertytest', function(err) {
+      lock.acquire('propertytest', function(err) {
         if (err) return done(err);
 
         lock.release(function(err) {

--- a/spec/lockSpec.js
+++ b/spec/lockSpec.js
@@ -1,12 +1,15 @@
-var expect    = require('expect.js');
-var Promise   = require('bluebird');
-var fakeredis = require('fakeredis');
-var rewire    = require('rewire');
+var expect     = require('expect.js');
+var Promise    = require('bluebird');
+var fakeredis  = require('fakeredis');
+var proxyquire = require('proxyquire');
 
 var helpers         = require('./redisHelpers');
 var mockShavaluator = require('./mockShavaluator');
 var redislock       = require('../lib/redislock');
-var Lock            = rewire('../lib/lock');
+var Lock            = proxyquire('../lib/lock', {
+  // Mock out redis-evalsha to emulate the lua script in unit tests
+  'redis-evalsha': mockShavaluator,
+});
 
 var LockAcquisitionError = redislock.LockAcquisitionError;
 var LockReleaseError     = redislock.LockReleaseError;
@@ -37,11 +40,6 @@ describe('lock', function() {
       return client.delAsync(lock._key).nodeify(fn);
     };
   };
-
-  before(function() {
-    // Mock out redis-evalsha to emulate the lua script in unit tests
-    Lock.__set__('Shavaluator', mockShavaluator);
-  });
 
   describe('constructor', function() {
     beforeEach(function() {


### PR DESCRIPTION
Upgrade bluebird, which doesn't require any changes:

> None of the changes apply to us. http://bluebirdjs.com/docs/new-in-bluebird-3.html
> We are using promisify, but we are not using callback adaptors.
> `nodeify` has been renamed. The old name exists, but I thought I'd go for it.

Shake some deprecated dev dependencies out of the tree, too, while we're here.